### PR TITLE
refactor: clean up UI elements in fretboard and bottom panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,14 @@
-
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import Index from "./pages/Index";
 import Upload from "./pages/Upload";
 import Workspace from "./pages/Workspace";
 import Features from "./pages/Features";
 import NotFound from "./pages/NotFound";
+import Header from '@/components/Header';
 
 const queryClient = new QueryClient();
 
@@ -18,13 +18,18 @@ const App = () => (
       <Toaster />
       <Sonner />
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/upload" element={<Upload />} />
-          <Route path="/workspace" element={<Workspace />} />
-          <Route path="/features" element={<Features />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <div className="flex flex-col min-h-screen">
+          <Header />
+          <main className="flex-1">
+            <Routes>
+              <Route path="/" element={<Index />} />
+              <Route path="/upload" element={<Upload />} />
+              <Route path="/workspace" element={<Workspace />} />
+              <Route path="/features" element={<Features />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </main>
+        </div>
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/ChordProgressionVisualizer.tsx
+++ b/src/components/ChordProgressionVisualizer.tsx
@@ -244,23 +244,6 @@ const ChordProgressionVisualizer: React.FC = () => {
   
   return (
     <div className="bg-sensei-card p-6 rounded-lg">
-      <h2 className="text-2xl font-bold mb-4">코드 진행 시각화</h2>
-      
-      <div className="mb-4">
-        <label className="block text-sm mb-1">코드 진행 선택:</label>
-        <select 
-          className="bg-sensei-secondary rounded p-2 w-full max-w-md"
-          value={selectedProgression}
-          onChange={(e) => {
-            setSelectedProgression(Number(e.target.value));
-            setCurrentChordIndex(0);
-          }}
-        >
-          {PROGRESSIONS.map((prog, idx) => (
-            <option key={idx} value={idx}>{prog.name}</option>
-          ))}
-        </select>
-      </div>
       
       {/* Full chord progression display */}
       <div className="mb-4 p-3 bg-gray-800 rounded-lg">

--- a/src/components/GuitarFretboard.tsx
+++ b/src/components/GuitarFretboard.tsx
@@ -67,16 +67,6 @@ const GuitarFretboard = ({ notes = [], onClick }: GuitarFretboardProps) => {
     <div className="w-full h-full bg-gray-900 overflow-auto p-4">
       <div className="flex items-center mb-4">
         <h3 className="text-lg font-medium">Guitar</h3>
-        <div className="ml-auto flex gap-2 text-xs text-gray-400">
-          <div className="flex items-center">
-            <div className="w-3 h-3 rounded-full bg-sensei-accent mr-1"></div>
-            <span>Root</span>
-          </div>
-          <div className="flex items-center">
-            <div className="w-3 h-3 rounded-full bg-gray-300 mr-1"></div>
-            <span>Chord Tone</span>
-          </div>
-        </div>
       </div>
       
       <div className="relative" style={{ height: fretboardHeight, width: fretboardWidth + 40 }}>

--- a/src/components/GuitarTabNotation.tsx
+++ b/src/components/GuitarTabNotation.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+
+export interface TabNote {
+  string: number; // 1-6 (1 is high E, 6 is low E)
+  fret: number;   // 0-24 (0 is open string)
+  position: number; // Position in the sequence (horizontal position)
+  duration?: number; // Duration of the note in beats
+  technique?: string; // e.g., "bend", "slide", "hammer-on", "pull-off", "vibrato", etc.
+  bendValue?: number; // How much to bend (e.g., 1 = full step, 0.5 = half step)
+  slideTarget?: number; // Target fret for slides
+}
+
+export interface GuitarTabNotationProps {
+  notes: TabNote[];
+  title?: string;
+  bpm?: number;
+  timeSignature?: string;
+  width?: number;
+  height?: number;
+}
+
+const GuitarTabNotation: React.FC<GuitarTabNotationProps> = ({
+  notes = [],
+  title = '',
+  bpm = 120,
+  timeSignature = '4/4',
+  width = 800,
+  height = 200,
+}) => {
+  // Sort notes by position
+  const sortedNotes = [...notes].sort((a, b) => a.position - b.position);
+  
+  // Find the maximum position to determine the width of the tab
+  const maxPosition = sortedNotes.length > 0
+    ? Math.max(...sortedNotes.map(note => note.position))
+    : 20; // Default minimum width
+  
+  // Column width for each position
+  const colWidth = 30;
+  
+  // Calculate the required width
+  const tabWidth = Math.max(width, (maxPosition + 5) * colWidth);
+  
+  // Guitar strings (standard tuning)
+  const strings = ['e', 'B', 'G', 'D', 'A', 'E']; // Displayed from top to bottom
+  
+  // Get technique symbol
+  const getTechniqueSymbol = (technique?: string, bendValue?: number): string => {
+    if (!technique) return '';
+    
+    switch (technique.toLowerCase()) {
+      case 'bend':
+        return `b${bendValue ? bendValue : ''}`;
+      case 'release':
+        return 'r';
+      case 'hammer-on':
+        return 'h';
+      case 'pull-off':
+        return 'p';
+      case 'slide-up':
+        return '/';
+      case 'slide-down':
+        return '\\';
+      case 'vibrato':
+        return '~';
+      default:
+        return '';
+    }
+  };
+
+  // Format fret number with technique
+  const formatFretWithTechnique = (note: TabNote): string => {
+    const fretStr = note.fret.toString().padStart(2, ' ').slice(-2);
+    const technique = getTechniqueSymbol(note.technique, note.bendValue);
+    return `${fretStr}${technique}`;
+  };
+  
+  return (
+    <div className="w-full overflow-auto">
+      <div style={{ width: tabWidth, minHeight: height }} className="font-mono text-sm">
+        {/* Tab header */}
+        <div className="mb-2">
+          {title && <div className="text-center font-bold mb-1">{title}</div>}
+          <div className="text-xs text-gray-400 flex gap-4 justify-center">
+            {bpm && <span>BPM: {bpm}</span>}
+            {timeSignature && <span>Time: {timeSignature}</span>}
+          </div>
+        </div>
+        
+        {/* Tab notation */}
+        <div className="bg-gray-800 rounded-md p-4">
+          {/* String labels and tab lines */}
+          <div className="relative border-l-2 border-gray-600">
+            {strings.map((string, index) => (
+              <div key={`string-${index}`} className="flex">
+                {/* String label */}
+                <div className="w-8 text-right pr-2 text-gray-400">{string}</div>
+                
+                {/* Tab line */}
+                <div className="flex-1 relative border-b border-gray-500 h-6">
+                  {/* Add notes for this string */}
+                  {sortedNotes
+                    .filter(note => note.string === index + 1)
+                    .map((note, noteIndex) => (
+                      <div 
+                        key={`note-${index}-${noteIndex}`}
+                        className="absolute text-sensei-accent"
+                        style={{ 
+                          left: `${note.position * colWidth}px`,
+                          top: '-8px',
+                        }}
+                      >
+                        {formatFretWithTechnique(note)}
+                      </div>
+                    ))}
+                </div>
+              </div>
+            ))}
+            
+            {/* Measure lines */}
+            {Array.from({ length: Math.ceil((maxPosition + 1) / 4) }).map((_, i) => (
+              <div
+                key={`measure-${i}`}
+                className="absolute h-full border-l border-gray-600"
+                style={{ left: `${(i + 1) * 4 * colWidth + 32}px` }}
+              ></div>
+            ))}
+          </div>
+          
+          {/* Position numbers */}
+          <div className="ml-8 flex text-xs text-gray-500 mt-1">
+            {Array.from({ length: Math.ceil((maxPosition + 1) / 4) }).map((_, i) => (
+              <div 
+                key={`pos-${i}`} 
+                style={{ width: `${4 * colWidth}px` }}
+                className="text-center"
+              >
+                {i + 1}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GuitarTabNotation; 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Link } from 'react-router-dom'; // Assuming you use react-router-dom
+import { Button } from '@/components/ui/button';
+import { LogIn } from 'lucide-react'; // Example icon
+
+const Header = () => {
+  return (
+    <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="container flex h-14 max-w-screen-2xl items-center">
+        {/* Logo */}
+        <Link to="/" className="mr-6 flex items-center space-x-2">
+          {/* Replace with your actual logo */}
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+            <path d="M9 18V5l12-2v13" />
+            <circle cx="6" cy="18" r="3" />
+            <circle cx="18" cy="16" r="3" />
+          </svg>
+          <span className="font-bold inline-block">ChordAICoach</span>
+        </Link>
+
+        {/* Navigation */}
+        <nav className="flex items-center gap-6 text-sm">
+          <Link
+            to="/features"
+            className="transition-colors hover:text-foreground/80 text-foreground/60"
+          >
+            Features
+          </Link>
+          <Link
+            to="/pricing"
+            className="transition-colors hover:text-foreground/80 text-foreground/60"
+          >
+            Pricing
+          </Link>
+          <Link
+            to="/about"
+            className="transition-colors hover:text-foreground/80 text-foreground/60"
+          >
+            About
+          </Link>
+        </nav>
+
+        {/* Right side actions (e.g., Login) */}
+        <div className="flex flex-1 items-center justify-end space-x-4">
+          <Button variant="ghost" size="sm">
+            <LogIn className="mr-2 h-4 w-4" />
+            Login
+          </Button>
+          {/* Add other actions like Sign Up if needed */}
+          {/* <Button size="sm">Sign Up</Button> */}
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default Header; 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,42 +6,44 @@ import { LogIn } from 'lucide-react'; // Example icon
 const Header = () => {
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-14 max-w-screen-2xl items-center">
-        {/* Logo */}
-        <Link to="/" className="mr-6 flex items-center space-x-2">
-          {/* Replace with your actual logo */}
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
-            <path d="M9 18V5l12-2v13" />
-            <circle cx="6" cy="18" r="3" />
-            <circle cx="18" cy="16" r="3" />
-          </svg>
-          <span className="font-bold inline-block">ChordAICoach</span>
-        </Link>
+      <div className="container flex h-14 max-w-screen-2xl items-center justify-between">
+        <div className="flex items-center"> {/* Group logo and nav */}
+          {/* Logo */}
+          <Link to="/" className="flex items-center space-x-2 md:mr-6"> {/* Responsive margin */}
+            {/* Replace with your actual logo */}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+              <path d="M9 18V5l12-2v13" />
+              <circle cx="6" cy="18" r="3" />
+              <circle cx="18" cy="16" r="3" />
+            </svg>
+            <span className="font-bold inline-block">ChordAICoach</span>
+          </Link>
 
-        {/* Navigation */}
-        <nav className="flex items-center gap-6 text-sm">
-          <Link
-            to="/features"
-            className="transition-colors hover:text-foreground/80 text-foreground/60"
-          >
-            Features
-          </Link>
-          <Link
-            to="/pricing"
-            className="transition-colors hover:text-foreground/80 text-foreground/60"
-          >
-            Pricing
-          </Link>
-          <Link
-            to="/about"
-            className="transition-colors hover:text-foreground/80 text-foreground/60"
-          >
-            About
-          </Link>
-        </nav>
+          {/* Navigation */}
+          <nav className="ml-6 flex items-center gap-4 md:gap-6 text-sm"> {/* Responsive gap and margin */}
+            <Link
+              to="/features"
+              className="transition-colors hover:text-foreground/80 text-foreground/60"
+            >
+              Features
+            </Link>
+            <Link
+              to="/pricing"
+              className="transition-colors hover:text-foreground/80 text-foreground/60"
+            >
+              Pricing
+            </Link>
+            <Link
+              to="/about"
+              className="transition-colors hover:text-foreground/80 text-foreground/60"
+            >
+              About
+            </Link>
+          </nav>
+        </div>
 
         {/* Right side actions (e.g., Login) */}
-        <div className="flex flex-1 items-center justify-end space-x-4">
+        <div className="flex items-center justify-end space-x-4">
           <Button variant="ghost" size="sm">
             <LogIn className="mr-2 h-4 w-4" />
             Login

--- a/src/components/KeyboardVisualizer.tsx
+++ b/src/components/KeyboardVisualizer.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+interface KeyboardVisualizerProps {
+  notes: string[];
+  rootNote: string;
+  chordNotes: string[];
+}
+
+const KeyboardVisualizer: React.FC<KeyboardVisualizerProps> = ({ 
+  notes = [], 
+  rootNote = "", 
+  chordNotes = []
+}) => {
+  // Piano keys - standard 2 octave (24 keys)
+  const whiteKeyNames = ['C', 'D', 'E', 'F', 'G', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'A', 'B'];
+  const blackKeyNames = ['C#', 'D#', '', 'F#', 'G#', 'A#', '', 'C#', 'D#', '', 'F#', 'G#', 'A#', ''];
+  
+  // 불협화음 목록 (현재 코드에 따라 다르게 설정할 수 있음)
+  // 일반적으로 주요 7도, 증4도/감5도 등이 불협화음으로 간주됨
+  const dissonantNotes: Record<string, string[]> = {
+    'C': ['F#', 'B'],
+    'D': ['G#', 'C#'],
+    'E': ['A#', 'D#'],
+    'F': ['B', 'E'],
+    'G': ['C#', 'F#'],
+    'A': ['D#', 'G#'],
+    'B': ['F', 'A#'],
+    'C#': ['G', 'C'],
+    'D#': ['A', 'D'],
+    'E#': ['B', 'E'],
+    'F#': ['C', 'F'],
+    'G#': ['D', 'G'],
+    'A#': ['E', 'A']
+  };
+  
+  // 현재 루트에 따른 불협화음 가져오기
+  const currentDissonantNotes = dissonantNotes[rootNote] || [];
+  
+  // Check if a note belongs to scale or chord, but not dissonant
+  const isInScale = (note: string) => notes.includes(note) && !currentDissonantNotes.includes(note);
+  const isInChord = (note: string) => chordNotes.includes(note);
+  const isRoot = (note: string) => note === rootNote;
+  
+  // Get key color based on note properties
+  const getKeyColor = (note: string) => {
+    if (isRoot(note)) return "bg-sensei-accent"; // Root note
+    if (isInChord(note)) return "bg-orange-400"; // Chord tone
+    if (isInScale(note)) return "bg-green-400"; // Scale note (excluding dissonant notes)
+    return ""; // Default color
+  };
+
+  return (
+    <div className="w-full h-full bg-gray-900 p-4">
+      <div className="flex items-center mb-4">
+        <h3 className="text-lg font-medium">Piano</h3>
+        
+        <div className="ml-auto flex gap-2 text-xs text-gray-400">
+          <div className="flex items-center">
+            <div className="w-3 h-3 rounded-full bg-sensei-accent mr-1"></div>
+            <span>루트</span>
+          </div>
+          <div className="flex items-center">
+            <div className="w-3 h-3 rounded-full bg-orange-400 mr-1"></div>
+            <span>코드 톤</span>
+          </div>
+          <div className="flex items-center">
+            <div className="w-3 h-3 rounded-full bg-green-400 mr-1"></div>
+            <span>협화음</span>
+          </div>
+        </div>
+      </div>
+      
+      <div className="relative w-full h-48">
+        <div className="absolute inset-0 flex">
+          {/* White keys */}
+          {whiteKeyNames.map((noteName, index) => (
+            <div
+              key={`white-key-${index}`}
+              className={`flex-1 border border-gray-700 rounded-b-md flex flex-col justify-end items-center pb-2 ${
+                getKeyColor(noteName) || "bg-white text-black hover:bg-gray-100"
+              }`}
+            >
+              <span className={`text-xs ${getKeyColor(noteName) ? "text-white" : "text-black"}`}>{noteName}</span>
+            </div>
+          ))}
+        </div>
+        
+        {/* Black keys */}
+        <div className="absolute inset-0 flex">
+          {blackKeyNames.map((noteName, index) => (
+            noteName !== "" && (
+              <div
+                key={`black-key-${index}`}
+                className={`absolute h-3/5 w-8 rounded-b-md z-10 ${
+                  getKeyColor(noteName) || "bg-black hover:bg-gray-800"
+                }`}
+                style={{ 
+                  left: `calc(${(index / blackKeyNames.length) * 100}% + 1.5%)`,
+                  marginLeft: index % 7 === 2 || index % 7 === 6 ? "0.6rem" : "0"
+                }}
+              >
+                <span className="absolute bottom-2 left-1/2 transform -translate-x-1/2 text-xs text-white">
+                  {noteName}
+                </span>
+              </div>
+            )
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default KeyboardVisualizer; 

--- a/src/components/LandingHero.tsx
+++ b/src/components/LandingHero.tsx
@@ -1,4 +1,3 @@
-
 import { Button } from "@/components/ui/button";
 import { ArrowRight, MusicIcon } from "lucide-react";
 import { useNavigate } from "react-router-dom";
@@ -11,7 +10,7 @@ const LandingHero = () => {
       <div className="absolute inset-0 bg-gradient-to-b from-sensei-background to-black opacity-50"></div>
       
       <div className="relative z-10 max-w-4xl mx-auto">
-        <div className="inline-block bg-sensei-accent p-2 px-4 rounded-full mb-6">
+        <div className="inline-block bg-sensei-accent p-2 px-4 rounded-full mb-6 mt-12">
           <p className="text-sm font-medium">Introducing ChordSensei AI</p>
         </div>
         

--- a/src/components/SoloAnalysis.tsx
+++ b/src/components/SoloAnalysis.tsx
@@ -4,10 +4,61 @@ import { BarChart, ChevronRight, Music, Radio } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import GuitarChordDiagram from "./GuitarChordDiagram";
 import GuitarFretboardWithScaleDisplay, { FretboardNote } from "./GuitarFretboardWithScaleDisplay";
+import KeyboardVisualizer from "./KeyboardVisualizer";
 import { getChordPositions } from "@/lib/chordPositions";
+import GuitarTabNotation, { TabNote } from "./GuitarTabNotation";
 
 // Define note names in order
 const NOTES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+
+// Chord types definitions
+const CHORD_TYPES: Record<string, { root: string; notes: string[]; description: string }> = {
+  "E7": {
+    root: "E",
+    notes: ["E", "G#", "B", "D"],
+    description: "E Dominant 7th (E7)"
+  },
+  "Am7": {
+    root: "A",
+    notes: ["A", "C", "E", "G"],
+    description: "A Minor 7th (Am7)"
+  },
+  "Cmaj7": {
+    root: "C",
+    notes: ["C", "E", "G", "B"],
+    description: "C Major 7th (Cmaj7)"
+  },
+  "G7": {
+    root: "G",
+    notes: ["G", "B", "D", "F"],
+    description: "G Dominant 7th (G7)"
+  },
+  "Dm7": {
+    root: "D",
+    notes: ["D", "F", "A", "C"],
+    description: "D Minor 7th (Dm7)"
+  },
+  "C": {
+    root: "C",
+    notes: ["C", "E", "G"],
+    description: "C Major"
+  },
+  "G": {
+    root: "G",
+    notes: ["G", "B", "D"],
+    description: "G Major"
+  },
+  "Am": {
+    root: "A",
+    notes: ["A", "C", "E"],
+    description: "A Minor"
+  },
+  "E": {
+    root: "E",
+    notes: ["E", "G#", "B"],
+    description: "E Major"
+  }
+};
 
 // Scale definitions with chord compatibility
 const SCALE_DEFINITIONS: Record<string, { 
@@ -193,6 +244,10 @@ interface SoloAnalysisProps {
   nextChord?: string;
 }
 
+// Keep track of chord changes with this global variable
+let chordChangeCount = 0;
+let lastSeenChord = "";
+
 const SoloAnalysis = ({ 
   currentChord, 
   feedback, 
@@ -206,12 +261,169 @@ const SoloAnalysis = ({
     initialScaleRecommendations || []
   );
   
+  // State to store the current recommended lick
+  const [currentRecommendedLick, setCurrentRecommendedLick] = useState<{
+    name: string;
+    description: string;
+    level: string;
+    tabNotes: TabNote[];
+    forChord: string;
+  } | null>(null);
+  
+  // All possible licks organized by chord
+  const licksByChord: Record<string, {
+    name: string;
+    description: string;
+    level: string;
+    tabNotes: TabNote[];
+  }[]> = {
+    "E7": [
+      {
+        name: "BBKing 벤딩 스타일",
+        description: "BBKing 스타일의 단음 벤딩으로 강한 표현력을 더함",
+        level: "초급",
+        tabNotes: [
+          { string: 2, fret: 8, position: 0 },
+          { string: 2, fret: 10, position: 2 },
+          { string: 2, fret: 8, position: 4, technique: "bend", bendValue: 0.5 },
+          { string: 2, fret: 8, position: 6 },
+          { string: 1, fret: 8, position: 8 },
+          { string: 1, fret: 10, position: 10 },
+          { string: 1, fret: 8, position: 12, technique: "bend", bendValue: 1 },
+          { string: 1, fret: 8, position: 14 },
+        ]
+      }
+    ],
+    "Am": [
+      {
+        name: "John Mayer 스타일 더블스탑",
+        description: "Slow Dancing의 더블스탑 벤딩을 활용한 표현",
+        level: "중급",
+        tabNotes: [
+          { string: 2, fret: 10, position: 0 },
+          { string: 1, fret: 8, position: 0 },
+          { string: 2, fret: 10, position: 2, technique: "bend", bendValue: 0.5 },
+          { string: 1, fret: 8, position: 2, technique: "bend", bendValue: 0.5 },
+          { string: 2, fret: 10, position: 4, technique: "bend", bendValue: 1 },
+          { string: 1, fret: 8, position: 4, technique: "bend", bendValue: 1 },
+          { string: 2, fret: 10, position: 6, technique: "release" },
+          { string: 1, fret: 8, position: 6, technique: "release" },
+          { string: 2, fret: 8, position: 8 },
+          { string: 3, fret: 9, position: 10 },
+          { string: 3, fret: 7, position: 12, technique: "hammer-on" },
+          { string: 3, fret: 9, position: 14, technique: "pull-off" },
+        ]
+      }
+    ],
+    "G": [
+      {
+        name: "SRV 블루스 터닝 포인트",
+        description: "텍사스 블루스의 전형적인 포지션 전환 패턴",
+        level: "고급",
+        tabNotes: [
+          { string: 3, fret: 7, position: 0 },
+          { string: 3, fret: 9, position: 1 },
+          { string: 3, fret: 7, position: 2, technique: "hammer-on" },
+          { string: 3, fret: 9, position: 3, technique: "pull-off" },
+          { string: 3, fret: 7, position: 4 },
+          { string: 4, fret: 9, position: 5 },
+          { string: 4, fret: 7, position: 6, technique: "slide-down" },
+          { string: 4, fret: 5, position: 7 },
+          { string: 5, fret: 7, position: 8 },
+          { string: 5, fret: 5, position: 9, technique: "slide-up" },
+          { string: 5, fret: 7, position: 10 },
+          { string: 4, fret: 5, position: 11 },
+          { string: 4, fret: 7, position: 12, technique: "bend", bendValue: 1.5 },
+          { string: 4, fret: 7, position: 14, technique: "vibrato" },
+        ]
+      }
+    ],
+    "C": [
+      {
+        name: "캄핑 스타일 아르페지오",
+        description: "C 메이저에서 순차적인 아르페지오 패턴",
+        level: "중급",
+        tabNotes: [
+          { string: 5, fret: 3, position: 0 },
+          { string: 4, fret: 2, position: 1 },
+          { string: 3, fret: 0, position: 2 },
+          { string: 2, fret: 1, position: 3 },
+          { string: 1, fret: 0, position: 4 },
+          { string: 2, fret: 1, position: 5 },
+          { string: 3, fret: 0, position: 6 },
+          { string: 4, fret: 2, position: 7 },
+          { string: 5, fret: 3, position: 8 },
+          { string: 4, fret: 2, position: 9 },
+          { string: 3, fret: 0, position: 10 },
+          { string: 2, fret: 1, position: 11 },
+        ]
+      }
+    ],
+    "A7": [
+      {
+        name: "A7 블루지 패턴",
+        description: "A7에서 미소리디안 모드를 활용한 블루스 패턴",
+        level: "초급",
+        tabNotes: [
+          { string: 3, fret: 6, position: 0 },
+          { string: 3, fret: 9, position: 1 },
+          { string: 3, fret: 7, position: 2 },
+          { string: 3, fret: 6, position: 3 },
+          { string: 2, fret: 8, position: 4 },
+          { string: 2, fret: 7, position: 5, technique: "bend", bendValue: 0.5 },
+          { string: 2, fret: 5, position: 6 },
+          { string: 3, fret: 7, position: 7 },
+          { string: 3, fret: 6, position: 8, technique: "vibrato" },
+        ]
+      }
+    ]
+  };
+  
+  // Default lick for any chord that doesn't have a specific recommendation
+  const defaultLick = {
+    name: "유니버설 포지션 패턴",
+    description: "어떤 코드에서도 활용 가능한 기본 포지션 패턴",
+    level: "초급",
+    tabNotes: [
+      { string: 3, fret: 4, position: 0 },
+      { string: 3, fret: 6, position: 1 },
+      { string: 3, fret: 7, position: 2 },
+      { string: 2, fret: 5, position: 3 },
+      { string: 2, fret: 7, position: 4 },
+      { string: 1, fret: 5, position: 5 },
+      { string: 1, fret: 7, position: 6 },
+      { string: 1, fret: 5, position: 7, technique: "bend", bendValue: 0.5 },
+    ]
+  };
+  
   // Update recommendations when chord changes
   useEffect(() => {
     // Generate fresh chord-specific recommendations
     const newRecommendations = getRecommendedScales(currentChord);
     setScaleRecommendations(newRecommendations);
-  }, [currentChord]);
+    
+    // Update chord change counter and lick if needed
+    if (currentChord !== lastSeenChord) {
+      lastSeenChord = currentChord;
+      chordChangeCount++;
+      
+      // Only update the lick every 2 chord changes
+      if (chordChangeCount % 2 === 0) {
+        const lick = licksByChord[currentChord]?.[0] || defaultLick;
+        setCurrentRecommendedLick({
+          ...lick,
+          forChord: currentChord
+        });
+      } else if (!currentRecommendedLick) {
+        // Initialize the lick if it's null
+        const lick = licksByChord[currentChord]?.[0] || defaultLick;
+        setCurrentRecommendedLick({
+          ...lick,
+          forChord: currentChord
+        });
+      }
+    }
+  }, [currentChord, currentRecommendedLick, licksByChord, defaultLick]);
   
   // Use the top recommended scale from the new recommendations
   const topRecommendedScale = scaleRecommendations.length > 0 
@@ -221,36 +433,21 @@ const SoloAnalysis = ({
   // State to store fretboard notes
   const [fretboardNotes, setFretboardNotes] = useState<FretboardNote[]>([]);
   
+  // Add instrument selection state
+  const [selectedInstrument, setSelectedInstrument] = useState<"guitar" | "piano">("guitar");
+  
   // Update fretboard notes when chord or scale changes
   useEffect(() => {
     const notes = generateFretboardNotes(currentChord, topRecommendedScale);
     setFretboardNotes(notes);
   }, [currentChord, topRecommendedScale]);
-  
+
   const formatTime = (ms: number) => {
     const totalSeconds = Math.floor(ms / 1000);
     const minutes = Math.floor(totalSeconds / 60);
     const seconds = totalSeconds % 60;
     return `${minutes}:${seconds.toString().padStart(2, '0')}`;
   };
-  
-  const recommendedLicks = [
-    {
-      name: "BBKing 벤딩 스타일",
-      description: "BBKing 스타일의 단음 벤딩으로 강한 표현력을 더함",
-      level: "초급",
-    },
-    {
-      name: "John Mayer 스타일 더블스탑",
-      description: "Slow Dancing의 더블스탑 벤딩을 활용한 표현",
-      level: "중급",
-    },
-    {
-      name: "SRV 블루스 터닝 포인트",
-      description: "텍사스 블루스의 전형적인 포지션 전환 패턴",
-      level: "고급",
-    }
-  ];
 
   return (
     <div className="p-4 h-full overflow-auto">
@@ -291,8 +488,24 @@ const SoloAnalysis = ({
       {/* Fretboard visualization showing scale and chord tones */}
       <div className="mb-4">
         <div className="flex justify-between items-center mb-2">
-          <div className="text-sm text-gray-400">
-            코드 톤 & 스케일 시각화 • <span className="text-sensei-accent">{currentChord}</span> + <span className="text-green-400">{topRecommendedScale}</span>
+          <div className="flex items-center gap-3">
+            <div className="text-sm text-gray-400">
+              코드 톤 & 스케일 시각화 • <span className="text-sensei-accent">{currentChord}</span> + <span className="text-green-400">{topRecommendedScale}</span>
+            </div>
+            <div className="flex bg-gray-800 rounded-md p-1">
+              <button 
+                className={`text-xs px-2 py-1 rounded ${selectedInstrument === "guitar" ? "bg-sensei-accent text-white" : "text-gray-400"}`}
+                onClick={() => setSelectedInstrument("guitar")}
+              >
+                기타
+              </button>
+              <button 
+                className={`text-xs px-2 py-1 rounded ${selectedInstrument === "piano" ? "bg-sensei-accent text-white" : "text-gray-400"}`}
+                onClick={() => setSelectedInstrument("piano")}
+              >
+                피아노
+              </button>
+            </div>
           </div>
           <div className="flex gap-2">
             <div className="flex items-center">
@@ -305,18 +518,35 @@ const SoloAnalysis = ({
             </div>
             <div className="flex items-center">
               <div className="w-3 h-3 rounded-full bg-green-400 mr-1"></div>
-              <span className="text-xs text-gray-400">스케일 음</span>
+              <span className="text-xs text-gray-400">
+                {selectedInstrument === "guitar" ? "스케일 음" : "협화음"}
+              </span>
             </div>
           </div>
         </div>
         
         <div className="h-72 border border-sensei-border rounded-lg">
-          <GuitarFretboardWithScaleDisplay 
-            key={`${currentChord}-${topRecommendedScale}`}
-            notes={fretboardNotes}
-            recommendedScale={topRecommendedScale}
-            recommendedChord={currentChord}
-          />
+          {selectedInstrument === "guitar" ? (
+            <GuitarFretboardWithScaleDisplay 
+              key={`guitar-${currentChord}-${topRecommendedScale}`}
+              notes={fretboardNotes}
+              recommendedScale={topRecommendedScale}
+              recommendedChord={currentChord}
+            />
+          ) : (
+            <KeyboardVisualizer 
+              key={`piano-${currentChord}-${topRecommendedScale}`}
+              notes={
+                SCALE_DEFINITIONS[topRecommendedScale]?.notes || []
+              }
+              rootNote={
+                SCALE_DEFINITIONS[topRecommendedScale]?.root || ""
+              }
+              chordNotes={
+                CHORD_TYPES[currentChord]?.notes || []
+              }
+            />
+          )}
         </div>
       </div>
 
@@ -415,30 +645,45 @@ const SoloAnalysis = ({
           <CardHeader className="pb-2">
             <CardTitle className="text-lg flex items-center">
               <BarChart className="mr-2 h-5 w-5 text-sensei-accent" />
-              추천 릭 & 프레이즈
+              추천 릭
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              {recommendedLicks.map((lick, index) => (
-                <div key={index} className="bg-gray-700 p-3 rounded-md">
+            <div className="space-y-6">
+              {currentRecommendedLick && (
+                <div className="bg-gray-700 p-3 rounded-md">
                   <div className="flex justify-between items-start">
-                    <h3 className="font-medium">{lick.name}</h3>
+                    <h3 className="font-medium">{currentRecommendedLick.name}</h3>
                     <Badge className={`
-                      ${lick.level === "초급" ? "bg-green-600" : 
-                        lick.level === "중급" ? "bg-yellow-600" : 
+                      ${currentRecommendedLick.level === "초급" ? "bg-green-600" : 
+                        currentRecommendedLick.level === "중급" ? "bg-yellow-600" : 
                         "bg-red-600"}
                     `}>
-                      {lick.level}
+                      {currentRecommendedLick.level}
                     </Badge>
                   </div>
-                  <p className="text-sm text-gray-300 mt-1">{lick.description}</p>
+                  <p className="text-sm text-gray-300 mt-1 mb-2">
+                    {currentRecommendedLick.description}
+                    <span className="ml-2 text-xs text-sensei-accent">
+                      추천 코드: {currentRecommendedLick.forChord}
+                    </span>
+                  </p>
+                  
+                  {/* Tab notation display */}
+                  <div className="mt-3 mb-3">
+                    <GuitarTabNotation 
+                      notes={currentRecommendedLick.tabNotes} 
+                      width={500}
+                      height={150}
+                    />
+                  </div>
+                  
                   <button className="mt-2 text-xs text-sensei-accent flex items-center">
                     릭 연습하기
                     <ChevronRight className="h-3 w-3 ml-1" />
                   </button>
                 </div>
-              ))}
+              )}
             </div>
           </CardContent>
         </Card>

--- a/src/pages/Features.tsx
+++ b/src/pages/Features.tsx
@@ -11,8 +11,6 @@ const Features = () => {
         <div className="grid grid-cols-1 gap-8">
           <ChordProgressionVisualizer />
           
-          <EnhancedGuitarVisualizer />
-          
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             <div className="bg-sensei-card p-6 rounded-lg">
               <h2 className="text-xl font-semibold mb-4">AI-Powered Song Analysis</h2>

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -243,7 +243,7 @@ const Workspace = () => {
               onClick={() => setShowSoloAnalysis(true)}
             >
               <Music2 className="h-4 w-4" />
-              솔로 분석
+              즉흥 연주
             </Button>
             <Button 
               variant={!showSoloAnalysis ? "default" : "outline"}

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import TransportControls from "@/components/TransportControls";
 import ChordGrid from "@/components/ChordGrid";
 import GuitarFretboard, { FretboardNote } from "@/components/GuitarFretboard";
@@ -6,7 +7,7 @@ import SoloAnalysis from "@/components/SoloAnalysis";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Download, Save, Share2, Volume2, Music2 } from "lucide-react";
+import { Download, Save, Share2, Volume2, Music2, Home } from "lucide-react";
 
 // Mock data for "Don't Look Back in Anger" C Major chord on the fretboard
 const cMajorChordNotes = [
@@ -69,6 +70,7 @@ const chordProgression = [
 ];
 
 const Workspace = () => {
+  const navigate = useNavigate();
   const [selectedInstrument, setSelectedInstrument] = useState("guitar");
   const [currentChord, setCurrentChord] = useState("C");
   const [fretboardNotes, setFretboardNotes] = useState(cMajorChordNotes);
@@ -194,7 +196,7 @@ const Workspace = () => {
   // Dependencies need careful consideration. 
   // playbackTime is included because it's read to calculate the *next* time. 
   // currentSoloNote drives the timing and note data.
-  }, [isPlayingSolo, currentSoloNote, playbackTime, soloNotes, chordProgression.length, soloFeedback.length]);
+  }, [isPlayingSolo, currentSoloNote, playbackTime]);
 
   // Calculate the combined notes (backing chord + solo notes)
   const displayedNotes = [...fretboardNotes, ...visibleNotes];
@@ -209,12 +211,11 @@ const Workspace = () => {
       {/* Main Content Area */}
       <div className="flex-1 flex flex-col">
         {/* Header with song info */}
-        <div className="bg-gray-900 border-b border-gray-800 p-4 flex items-center">
+        <div className="bg-gray-900 border-b border-gray-800 p-4 flex items-center gap-4">
           <div>
             <h1 className="text-xl font-bold">Don't Look Back in Anger</h1>
             <p className="text-gray-400 text-sm">Oasis - 4:48</p>
           </div>
-
           
           <div className="ml-auto flex gap-2">
             <Button variant="outline" size="sm" className="flex items-center gap-1 bg-transparent border-gray-700 hover:bg-gray-800">

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -214,6 +214,7 @@ const Workspace = () => {
             <h1 className="text-xl font-bold">Don't Look Back in Anger</h1>
             <p className="text-gray-400 text-sm">Oasis - 4:48</p>
           </div>
+
           
           <div className="ml-auto flex gap-2">
             <Button variant="outline" size="sm" className="flex items-center gap-1 bg-transparent border-gray-700 hover:bg-gray-800">
@@ -230,32 +231,9 @@ const Workspace = () => {
             </Button>
           </div>
         </div>
-        
-        {/* Chord Grid Area */}
-        <div className="flex-1 overflow-auto">
-          {!showSoloAnalysis ? (
-            <div className="flex flex-col h-full">
-              <div className="flex-1 overflow-auto">
-                <ChordGrid />
-              </div>
-              <div className="h-52 border-t border-gray-800 bg-gray-900">
-                <GuitarFretboard notes={displayedNotes} />
-              </div>
-            </div>
-          ) : (
-            <SoloAnalysis 
-              currentChord={currentChord} 
-              feedback={soloFeedback[feedbackIndex]} 
-              scaleRecommendations={scaleRecommendations}
-              playbackTime={playbackTime}
-              previousChord={getPreviousChord()}
-              nextChord={getNextChord()}
-            />
-          )}
-        </div>
-        
-        {/* Toggle button for chord grid / solo analysis */}
-        <div className="border-t border-gray-800 bg-gray-900 py-2 px-4 flex justify-between items-center">
+
+                {/* Toggle button for chord grid / solo analysis */}
+                <div className="border-t border-gray-800 bg-gray-900 py-2 px-4 flex justify-between items-center">
           <div className="flex gap-2">
             <Button 
               variant={showSoloAnalysis ? "default" : "outline"}
@@ -287,64 +265,28 @@ const Workspace = () => {
           </Button>
         </div>
         
-        {/* Bottom Instrument Panel - Only show when Solo Analysis is active */}
-        {showSoloAnalysis && (
-          <div className="h-52 border-t border-gray-800 bg-gray-900">
-            <Tabs defaultValue="guitar" className="w-full h-full">
-              <div className="flex border-b border-gray-800">
-                <TabsList className="bg-gray-900 h-12 px-4">
-                  <TabsTrigger 
-                    value="sheet" 
-                    className="data-[state=active]:bg-gray-800 data-[state=active]:text-white"
-                  >
-                    Staff Notation
-                  </TabsTrigger>
-                  <TabsTrigger 
-                    value="keyboard" 
-                    className="data-[state=active]:bg-gray-800 data-[state=active]:text-white"
-                  >
-                    Keyboard
-                  </TabsTrigger>
-                  <TabsTrigger 
-                    value="guitar" 
-                    className="data-[state=active]:bg-gray-800 data-[state=active]:text-white"
-                  >
-                    Guitar
-                  </TabsTrigger>
-                </TabsList>
-                <div className="ml-auto flex items-center pr-4">
-                  <Badge className="mr-3 bg-sensei-accent/20 text-sensei-accent border border-sensei-accent/30">
-                    {currentChord}
-                  </Badge>
-                  <Button 
-                    onClick={handleChordToggle}
-                    variant="outline" 
-                    size="sm"
-                    className="bg-transparent border-gray-700 hover:bg-gray-800"
-                  >
-                    Show {currentChord === "C" ? "E7" : "C"} Voicing
-                  </Button>
-                </div>
+        {/* Chord Grid Area */}
+        <div className="flex-1 overflow-auto">
+          {!showSoloAnalysis ? (
+            <div className="flex flex-col h-full">
+              <div className="flex-1 overflow-auto">
+                <ChordGrid />
               </div>
-              
-              <TabsContent value="sheet" className="h-full">
-                <div className="flex items-center justify-center h-full text-gray-400">
-                  <p>Staff notation will be displayed here</p>
-                </div>
-              </TabsContent>
-              
-              <TabsContent value="keyboard" className="h-full">
-                <div className="flex items-center justify-center h-full text-gray-400">
-                  <p>Keyboard visualization will be displayed here</p>
-                </div>
-              </TabsContent>
-              
-              <TabsContent value="guitar" className="h-full">
+              <div className="h-52 border-t border-gray-800 bg-gray-900">
                 <GuitarFretboard notes={displayedNotes} />
-              </TabsContent>
-            </Tabs>
-          </div>
-        )}
+              </div>
+            </div>
+          ) : (
+            <SoloAnalysis 
+              currentChord={currentChord} 
+              feedback={soloFeedback[feedbackIndex]} 
+              scaleRecommendations={scaleRecommendations}
+              playbackTime={playbackTime}
+              previousChord={getPreviousChord()}
+              nextChord={getNextChord()}
+            />
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
- Remove legend ("Root", "Chord Tone") from GuitarFretboard component.
- Remove instrument tabs and chord display/toggle from the bottom panel in the Solo Analysis view.
- Adjust bottom panel height in Solo Analysis view to fit content dynamically.